### PR TITLE
Externalise the duration label

### DIFF
--- a/templates/boxmenu-item.hbs
+++ b/templates/boxmenu-item.hbs
@@ -14,7 +14,7 @@
 		<a href="#/id/{{_id}}" class="{{#if _isVisited}}visited{{/if}}">
 			{{{linkText}}}
 		</a>
-		<span class="menu-item-duration">{{{durationLabel}}} {{{duration}}}</span>
+		<span class="menu-item-duration">{{#if durationLabel}}{{{durationLabel}}}{{else}}Duration:{{/if}} {{{duration}}}</span>
 	</div>
 	<div class="menu-item-progress">
 		<div class="menu-item-progress-indicator">

--- a/templates/boxmenu-item.hbs
+++ b/templates/boxmenu-item.hbs
@@ -14,7 +14,7 @@
 		<a href="#/id/{{_id}}" class="{{#if _isVisited}}visited{{/if}}">
 			{{{linkText}}}
 		</a>
-		<span class="menu-item-duration">Duration: {{{duration}}}</span>
+		<span class="menu-item-duration">{{{durationLabel}}} {{{duration}}}</span>
 	</div>
 	<div class="menu-item-progress">
 		<div class="menu-item-progress-indicator">


### PR DESCRIPTION
It was obviously missed that any text displayed should be externalised into JSON files, I've pulled out the "Duration:" label into `durationLabel` property.

    {
        "_id":"co-01",
        "_parentId":"course",
        "_type":"page",
        "linkText":"View",
        "durationLabel":"Duration:",
        "duration":"5 mins"
    },