### PR TITLE
Lukasz Grela - externalise "Duration" into durationLabel JSON property

### DIFF
--- a/example.json
+++ b/example.json
@@ -15,6 +15,7 @@
             "linkText": "Select here to view."
         },
         "linkText":"View",
+        "durationLabel":"Duration:",
         "duration":"2 mins"
     }
 

--- a/templates/boxmenu-item.hbs
+++ b/templates/boxmenu-item.hbs
@@ -15,7 +15,7 @@
             {{{linkText}}}
         </a>
         {{#if duration}}
-            <span class="menu-item-duration">Duration: {{{duration}}}</span>
+            <span class="menu-item-duration">{{#if durationLabel}}{{{durationLabel}}}{{else}}Duration:{{/if}} {{{duration}}}</span>
         {{/if}}
     </div>
 </div>


### PR DESCRIPTION
It was obviously missed that any text displayed should be externalised into JSON files, I've pulled out the "Duration:" label into `durationLabel` property.

    {
        "_id":"co-01",
        "_parentId":"course",
        "_type":"page",
        "linkText":"View",
        "durationLabel":"Duration:",
        "duration":"5 mins"
    },
