### PR TITLE
Title and body wrapped in header element

### DIFF
--- a/templates/boxmenu.hbs
+++ b/templates/boxmenu.hbs
@@ -1,18 +1,22 @@
 <div class="menu-container" role="region" aria-label="{{_globals._accessibility._ariaLabels.menu}}" {{#if _globals._accessibility._ariaLabels.menu}}tabindex="0"{{/if}}>
 	<div class='menu-container-inner box-menu-inner clearfix'>
-		{{#if title}}
-		<div class="menu-title">
-			<div class="menu-title-inner h1 accessible-text-block" role="heading" aria-level="1" tabindex="0">
-				{{{title}}}
+		<div class="menu-header">
+			<div class="menu-header-inner">
+				{{#if title}}
+				<div class="menu-title">
+					<div class="menu-title-inner h1 accessible-text-block" role="heading" aria-level="1" tabindex="0">
+						{{{title}}}
+					</div>
+				</div>
+				{{/if}}
+				{{#if body}}
+				<div class="menu-body">
+					<div class="menu-body-inner accessible-text-block">
+						{{{a11y_text body}}}
+					</div>
+				</div>
+				{{/if}}
 			</div>
 		</div>
-		{{/if}}
-		{{#if body}}
-		<div class="menu-body">
-			<div class="menu-body-inner accessible-text-block">
-				{{{a11y_text body}}}
-			</div>
-		</div>
-		{{/if}}
 	</div>
 </div>


### PR DESCRIPTION
- one selector can be used to style rather than selecting title and body separately.
- offers more flexibility when styling - separate menu content, set backgrounds/widths - I find myself constantly adding this in on project work.