### PR TITLE
ABU-710: Fixed menu completion calculation to use model

### DIFF
--- a/js/adapt-contrib-boxmenu.js
+++ b/js/adapt-contrib-boxmenu.js
@@ -38,19 +38,14 @@ define(function(require) {
         },
 
         preRender: function() {
-            this.model.set('_isComplete', this.isCompleted());
+            this.model.checkCompletionStatus();
+            this.model.checkInteractionCompletionStatus();
         },
 
         postRender: function() {
             this.$el.imageready(_.bind(function() {
                 this.setReadyStatus();
             }, this));
-        },
-
-        isCompleted: function() {
-            return _.every(this.model.findDescendants('components').models, function (item) {
-                return item.get('_isComplete');
-            });
         }
 
     }, {


### PR DESCRIPTION
The menu was resetting it's own completion if any _isOptional components existed by weren't complete.

* Use model completion calculation to include _isOptionals etc for standard behaviour

Should be checked with:
https://github.com/adaptlearning/adapt-contrib-assessment/pull/45
https://github.com/adaptlearning/adapt_framework/pull/659
https://github.com/adaptlearning/adapt-contrib-pageLevelProgress/pull/54