### PR TITLE
Remove hard coded "Duration:"

### DIFF
--- a/templates/boxmenu-item.hbs
+++ b/templates/boxmenu-item.hbs
@@ -13,7 +13,7 @@
             {{{linkText}}}
         </a>
         {{#if duration}}
-            <span class="menu-item-duration accessible-text-block" role="region" tabindex="0">{{#if durationLabel}}{{{durationLabel}}}{{else}}Duration:{{/if}} {{{duration}}}</span>
+            <span class="menu-item-duration accessible-text-block" role="region" tabindex="0">{{#if durationLabel}}{{{durationLabel}}}{{/if}} {{{duration}}}</span>
         {{/if}}
     </div>
 </div>


### PR DESCRIPTION
I believe we shouldn't have "else" in the following line of code: https://github.com/adaptlearning/adapt-contrib-boxmenu/blob/master/templates/boxmenu-item.hbs#L16 , if a user doesn't want to specify the durationLable then it should be empty, and if the language is not English, then they will be forced to have the word "duration" in a different language course.