### PR TITLE
accessibility: fixes issue/#2075 issue/#2084 issue/#2084 issue/#2118 issue/#2119

### DIFF
--- a/js/adapt-contrib-boxmenu.js
+++ b/js/adapt-contrib-boxmenu.js
@@ -10,11 +10,10 @@ define([
         },
 
         attributes: function() {
-            return {
+            return MenuView.prototype.resultExtend('attributes', {
                 'role': 'main',
-                'aria-labelledby': this.model.get('_id')+'-heading',
-                'data-adapt-id': this.model.get('_id')
-            };
+                'aria-labelledby': this.model.get('_id')+'-heading'
+            }, this);
         },
 
         postRender: function() {

--- a/js/adapt-contrib-boxmenu.js
+++ b/js/adapt-contrib-boxmenu.js
@@ -42,11 +42,10 @@ define([
         },
 
         attributes: function() {
-            return {
-                'data-adapt-id': this.model.get('_id'),
+            return MenuView.prototype.resultExtend('attributes', {
                 'role': 'listitem',
                 'aria-labelledby': this.model.get('_id') + '-heading'
-            };
+            }, this);
         },
 
         className: function() {

--- a/js/adapt-contrib-boxmenu.js
+++ b/js/adapt-contrib-boxmenu.js
@@ -9,12 +9,20 @@ define([
             return MenuView.prototype.className.apply(this) + " boxmenu-menu";
         },
 
+        attributes: function() {
+            return {
+                'role': 'main',
+                'aria-labelledby': this.model.get('_id')+'-heading',
+                'data-adapt-id': this.model.get('_id')
+            };
+        },
+
         postRender: function() {
             var nthChild = 0;
             this.model.getChildren().each(function(item) {
                 if (item.get('_isAvailable') && !item.get('_isHidden')) {
                     item.set('_nthChild', ++nthChild);
-                    this.$('.menu-container-inner').append(new BoxMenuItemView({model: item}).$el);
+                    this.$('.js-children').append(new BoxMenuItemView({model: item}).$el);
                 }
 
                 if(item.get('_isHidden')) {
@@ -31,6 +39,14 @@ define([
 
         events: {
             'click button' : 'onClickMenuItemButton'
+        },
+
+        attributes: function() {
+            return {
+                'data-adapt-id': this.model.get('_id'),
+                'role': 'listitem',
+                'aria-labelledby': this.model.get('_id') + '-heading'
+            };
         },
 
         className: function() {

--- a/properties.schema
+++ b/properties.schema
@@ -4,34 +4,10 @@
   "id": "http://jsonschema.net",
   "$ref": "http://localhost/plugins/content/contentobject/model.schema",
   "globals": {
-    "ariaRegion": {
-      "type": "string",
-      "required": true,
-      "default": "Menu",
-      "inputType": "Text",
-      "validators": [],
-      "translatable": true
-    },
     "durationLabel": {
       "type": "string",
       "required": true,
       "default": "Duration:",
-      "inputType": "Text",
-      "validators": [],
-      "translatable": true
-    },
-    "menuItem": {
-      "type": "string",
-      "required": true,
-      "default": "Menu item.",
-      "inputType": "Text",
-      "validators": [],
-      "translatable": true
-    },
-    "menuEnd": {
-      "type": "string",
-      "required": true,
-      "default": "You have reached the end of the menu.",
       "inputType": "Text",
       "validators": [],
       "translatable": true

--- a/templates/boxmenu-item.hbs
+++ b/templates/boxmenu-item.hbs
@@ -18,7 +18,7 @@
             <span class="menu-item-duration">{{#if _globals._menu._boxmenu.durationLabel}}{{{_globals._menu._boxmenu.durationLabel}}}{{/if}} {{{duration}}}</span>
         {{/if}}
         <div class="js-progress"></div>
-        <button aria-label="{{linkText}} {{#if _isVisited}}{{_globals._accessibility._ariaLabels.visited}}{{/if}}" class="{{#if _isVisited}}visited{{/if}} {{#if _isLocked}}disabled{{/if}}" {{#if _isLocked}}disabled="disabled"{{/if}}>
+        <button aria-label="{{#if _isVisited}}{{_globals._accessibility._ariaLabels.visited}}{{/if}} {{linkText}}" class="{{#if _isVisited}}visited{{/if}} {{#if _isLocked}}disabled{{/if}}" {{#if _isLocked}}disabled="disabled"{{/if}}>
             {{{linkText}}}
         </button>
     </div>

--- a/templates/boxmenu-item.hbs
+++ b/templates/boxmenu-item.hbs
@@ -3,7 +3,7 @@
     {{a11y_aria_label _globals._menu._boxmenu.menuItem}}
     <div class="menu-item-graphic">
         {{#if _graphic.src}}
-            <img src="{{_graphic.src}}"{{#if _graphic.alt}} aria-label="{{_graphic.alt}}"{{/if}} />
+            <img src="{{_graphic.src}}" aria-label="{{_graphic.alt}}" />
         {{/if}}
     </div>
     <div class="menu-item-title">

--- a/templates/boxmenu-item.hbs
+++ b/templates/boxmenu-item.hbs
@@ -1,23 +1,25 @@
 {{import_globals}}
 <div class="menu-item-inner">
-    {{a11y_aria_label _globals._menu._boxmenu.menuItem}}
     <div class="menu-item-graphic">
         {{#if _graphic.src}}
-            <img src="{{_graphic.src}}" aria-label="{{_graphic.alt}}" />
+            <img src="{{_graphic.src}}" aria-hidden="true" />
         {{/if}}
     </div>
     <div class="menu-item-title">
-        <div class="menu-item-title-inner h3" role="heading" aria-level="2">{{{compile displayTitle}}}</div>
+        <div class="js-heading" data-a11y-heading-type="menuItem"></div>
+        <div class="menu-item-title-inner h3 accessible-text-block" aria-hidden="true">{{{compile displayTitle}}}</div>
     </div>
+    {{a11y_aria_label _graphic.alt}}
     <div class="menu-item-body">
         <div class="menu-item-body-inner">{{{compile body}}}</div>
     </div>
     <div class="menu-item-button">
-        <button aria-label="{{linkText}} {{#if _isVisited}}{{_globals._accessibility._ariaLabels.visited}}{{/if}}" class="{{#if _isVisited}}visited{{/if}} {{#if _isLocked}}disabled{{/if}}" {{#if _isLocked}}disabled="disabled"{{/if}}>
-            {{{linkText}}}
-        </button>
         {{#if duration}}
             <span class="menu-item-duration">{{#if _globals._menu._boxmenu.durationLabel}}{{{_globals._menu._boxmenu.durationLabel}}}{{/if}} {{{duration}}}</span>
         {{/if}}
+        <div class="js-progress"></div>
+        <button aria-label="{{linkText}} {{#if _isVisited}}{{_globals._accessibility._ariaLabels.visited}}{{/if}}" class="{{#if _isVisited}}visited{{/if}} {{#if _isLocked}}disabled{{/if}}" {{#if _isLocked}}disabled="disabled"{{/if}}>
+            {{{linkText}}}
+        </button>
     </div>
 </div>

--- a/templates/boxmenu-item.hbs
+++ b/templates/boxmenu-item.hbs
@@ -8,7 +8,7 @@
         <div class="menu-item-title-inner h3" role="heading" aria-level="2" tabindex="0">{{{compile displayTitle}}}</div>
     </div>
     <div class="menu-item-body">
-        <div class="menu-item-body-inner">{{{compile_a11y_text body}}}</div>
+        <div class="menu-item-body-inner">{{{compile body}}}</div>
     </div>
     <div class="menu-item-button">
         <button aria-label="{{linkText}} {{#if _isVisited}}{{_globals._accessibility._ariaLabels.visited}}{{/if}}" class="{{#if _isVisited}}visited{{/if}} {{#if _isLocked}}disabled{{/if}}" {{#if _isLocked}}disabled="disabled"{{/if}}>

--- a/templates/boxmenu-item.hbs
+++ b/templates/boxmenu-item.hbs
@@ -17,7 +17,7 @@
         {{#if duration}}
             <span class="menu-item-duration">{{#if _globals._menu._boxmenu.durationLabel}}{{{_globals._menu._boxmenu.durationLabel}}}{{/if}} {{{duration}}}</span>
         {{/if}}
-        <div class="js-progress"></div>
+        <div class="js-menu-item-progress"></div>
         <button aria-label="{{#if _isVisited}}{{_globals._accessibility._ariaLabels.visited}}{{/if}} {{linkText}}" class="{{#if _isVisited}}visited{{/if}} {{#if _isLocked}}disabled{{/if}}" {{#if _isLocked}}disabled="disabled"{{/if}}>
             {{{linkText}}}
         </button>

--- a/templates/boxmenu-item.hbs
+++ b/templates/boxmenu-item.hbs
@@ -1,11 +1,13 @@
-<div class="menu-item-inner" aria-label="{{_globals._menu._boxmenu.menuItem}}" {{#if _globals._menu._boxmenu.menuItem}}tabindex="0"{{/if}}>
+{{import_globals}}
+<div class="menu-item-inner">
+    {{a11y_aria_label _globals._menu._boxmenu.menuItem}}
     <div class="menu-item-graphic">
         {{#if _graphic.src}}
-            <img src="{{_graphic.src}}" alt="{{_graphic.alt}}" />
+            <img src="{{_graphic.src}}"{{#if _graphic.alt}} aria-label="{{_graphic.alt}}"{{/if}} />
         {{/if}}
     </div>
     <div class="menu-item-title">
-        <div class="menu-item-title-inner h3" role="heading" aria-level="2" tabindex="0">{{{compile displayTitle}}}</div>
+        <div class="menu-item-title-inner h3" role="heading" aria-level="2">{{{compile displayTitle}}}</div>
     </div>
     <div class="menu-item-body">
         <div class="menu-item-body-inner">{{{compile body}}}</div>
@@ -15,7 +17,7 @@
             {{{linkText}}}
         </button>
         {{#if duration}}
-            <span class="menu-item-duration" role="region" tabindex="0">{{#if _globals._menu._boxmenu.durationLabel}}{{{_globals._menu._boxmenu.durationLabel}}}{{/if}} {{{duration}}}</span>
+            <span class="menu-item-duration">{{#if _globals._menu._boxmenu.durationLabel}}{{{_globals._menu._boxmenu.durationLabel}}}{{/if}} {{{duration}}}</span>
         {{/if}}
     </div>
 </div>

--- a/templates/boxmenu.hbs
+++ b/templates/boxmenu.hbs
@@ -1,12 +1,14 @@
 {{import_globals}}
 <div class="menu-container">
-	{{a11y_aria_label _globals._menu._boxmenu.ariaRegion}}
 	<div class='menu-container-inner box-menu-inner clearfix'>
 		<div class="menu-header">
 			<div class="menu-header-inner">
 				{{#if displayTitle}}
 				<div class="menu-title">
-					<div class="menu-title-inner h1" role="heading" aria-level="1">
+					{{#unless _disableAccessibleState}}
+						<div class="js-heading"></div>
+					{{/unless}}
+					<div class="menu-title-inner h1" {{#unless _disableAccessibleState}}aria-hidden="true"{{/unless}}>
 						{{{compile displayTitle}}}
 					</div>
 				</div>
@@ -20,6 +22,8 @@
 				{{/if}}
 			</div>
 		</div>
+		<div class="js-children" role="list">
+
+		</div>
 	</div>
-	{{a11y_aria_label_relative _globals._menu._boxmenu.menuEnd}}
 </div>

--- a/templates/boxmenu.hbs
+++ b/templates/boxmenu.hbs
@@ -12,7 +12,7 @@
 				{{#if body}}
 				<div class="menu-body">
 					<div class="menu-body-inner">
-						{{{compile_a11y_text body}}}
+						{{{compile body}}}
 					</div>
 				</div>
 				{{/if}}

--- a/templates/boxmenu.hbs
+++ b/templates/boxmenu.hbs
@@ -1,10 +1,12 @@
-<div class="menu-container" role="region" aria-label="{{_globals._menu._boxmenu.ariaRegion}}">
+{{import_globals}}
+<div class="menu-container">
+	{{a11y_aria_label _globals._menu._boxmenu.ariaRegion}}
 	<div class='menu-container-inner box-menu-inner clearfix'>
 		<div class="menu-header">
 			<div class="menu-header-inner">
 				{{#if displayTitle}}
 				<div class="menu-title">
-					<div class="menu-title-inner h1" role="heading" aria-level="1" tabindex="0">
+					<div class="menu-title-inner h1" role="heading" aria-level="1">
 						{{{compile displayTitle}}}
 					</div>
 				</div>
@@ -19,5 +21,5 @@
 			</div>
 		</div>
 	</div>
-	<div class="aria-label relative a11y-ignore-focus prevent-default" tabindex="0" role="region">{{_globals._menu._boxmenu.menuEnd}}</div>
+	{{a11y_aria_label_relative _globals._menu._boxmenu.menuEnd}}
 </div>


### PR DESCRIPTION
[#2075](https://github.com/adaptlearning/adapt_framework/issues/2075)
* Removed a11y_text
* Removed unnecessary tabindex

[#2083](https://github.com/adaptlearning/adapt_framework/issues/2083)
* Added heading completion statuses

[#2084](https://github.com/adaptlearning/adapt_framework/issues/2084)
* Removed component description

[#2118](https://github.com/adaptlearning/adapt_framework/issues/2118);
*  Added list roles

[#2119](https://github.com/adaptlearning/adapt_framework/issues/2119)
* Moved duration label and progress indicator

General
* Switch at `a11y_aria_label`

List of outstanding PRs: https://github.com/adaptlearning/adapt_framework/issues/2206.
