### PR TITLE
Update boxmenu-item.hbs

### DIFF
--- a/templates/boxmenu-item.hbs
+++ b/templates/boxmenu-item.hbs
@@ -9,7 +9,7 @@
         <div class="js-heading" data-a11y-heading-type="menuItem"></div>
         <div class="menu-item-title-inner h3 accessible-text-block" aria-hidden="true">{{{compile displayTitle}}}</div>
     </div>
-    {{a11y_aria_image _graphic.alt}}
+    {{#if _graphic.src}}{{a11y_aria_image _graphic.alt}}{{/if}}
     <div class="menu-item-body">
         <div class="menu-item-body-inner">{{{compile body}}}</div>
     </div>


### PR DESCRIPTION
Changed to only show image label if there is an image as an empty image label reduces accessibility score in Lighthouse.