### PR TITLE
remove class accessible-text-block

### DIFF
--- a/templates/boxMenuItem.hbs
+++ b/templates/boxMenuItem.hbs
@@ -15,7 +15,7 @@
       <div class="menu-item__title boxmenu-item__title">
         <div class="js-heading" data-a11y-heading-type="menuItem"></div>
 
-        <div class="menu-item__title-inner boxmenu-item__title-inner accessible-text-block" aria-hidden="true">
+        <div class="menu-item__title-inner boxmenu-item__title-inner" aria-hidden="true">
           {{{compile displayTitle}}}
         </div>
       </div>


### PR DESCRIPTION
it's not needed by the a11y functionality any more (in fact this is the only reference to it I can find in Adapt v5)