### PR TITLE
Fix: Add option to add a graphic to the menu header (fixes #133)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ The following attributes, set within *course.json*, configure the defaults for *
 
 **\_boxMenu** (object): The boxMenu object that contains value for **\_backgroundImage**, **\_backgroundStyles**, and **\_menuHeader**.
 
+>**\_graphic_** (object): The graphic object that contains values for **\_src** and **alt**. Typically used to display a logo image
+
+>>**\_src** (string): File name (including path) of the image
+
+>>**alt** (string): A description of the image; required when it has meaning that must be conveyed to the learner. For 'decorative' images, leave this blank
+
 >**\_backgroundImage** (object): The backgroundImage object that contains values for **\_large**, **\_medium** and **\_small**.
 
 >>**\_large** (string): File name (including path) of the image used with large device width. Path should be relative to the *src* folder (e.g., *course/en/images/origami-menu-one.jpg*).

--- a/example.json
+++ b/example.json
@@ -1,5 +1,9 @@
     // course.json
     "_boxMenu": {
+        "_graphic": {
+            "alt": "Logo",
+            "_src": "course/en/images/logo-graphic.jpg"
+        },
         "_backgroundImage": {
             "_large": "course/en/images/example.jpg",
             "_medium": "course/en/images/example.jpg",

--- a/example.json
+++ b/example.json
@@ -1,7 +1,7 @@
     // course.json
     "_boxMenu": {
         "_graphic": {
-            "alt": "Logo",
+            "alt": "",
             "_src": "course/en/images/logo-graphic.jpg"
         },
         "_backgroundImage": {

--- a/less/boxMenu.less
+++ b/less/boxMenu.less
@@ -5,6 +5,10 @@
     .l-container-responsive(@max-content-width);
   }
 
+  &__image {
+    min-width: auto;
+  }
+
   &__item-container &__item-container-inner {
     display: flex;
     flex-wrap: wrap;

--- a/properties.schema
+++ b/properties.schema
@@ -28,6 +28,31 @@
               "type": "object",
               "required": false,
               "properties": {
+                "_graphic": {
+                  "type": "object",
+                  "required": false,
+                  "legend": "Menu logo image",
+                  "properties": {
+                    "_src": {
+                      "type": "string",
+                      "inputType": "Asset:image",
+                      "validators": [],
+                      "title": "Source",
+                      "help": "This image will appear above the menu page title",
+                      "required": false,
+                      "default": ""
+                    },
+                    "alt": {
+                      "type": "string",
+                      "inputType": "Text",
+                      "validators": [],
+                      "title": "Alternative text",
+                      "help": "A description of the image; required when it has meaning that must be conveyed to the learner. For 'decorative' images, leave this blank",
+                      "required": false,
+                      "translatable": true
+                    }
+                  }
+                },
                 "_backgroundImage": {
                   "type": "object",
                   "required": false,

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -33,6 +33,32 @@
           "title": "Box Menu",
           "default": {},
           "properties": {
+            "_graphic": {
+              "type": "object",
+              "title": "Menu logo image",
+              "default": {},
+              "properties": {
+                "_src": {
+                  "type": "string",
+                  "isObjectId": true,
+                  "title": "Source",
+                  "description": "This image will appear above the menu page title",
+                  "_backboneForms": {
+                    "type": "Asset",
+                    "media": "image"
+                  }
+                },
+                "alt": {
+                  "type": "string",
+                  "title": "Alternative text",
+                  "description": "A description of the image; required when it has meaning that must be conveyed to the learner. For 'decorative' images, leave this blank",
+                  "default": "",
+                  "_adapt": {
+                    "translatable": true
+                  }
+                }
+              }
+            },
             "_backgroundImage": {
               "type": "object",
               "title": "Background image",

--- a/templates/boxMenu.hbs
+++ b/templates/boxMenu.hbs
@@ -6,6 +6,12 @@
   <div class="menu__header boxmenu__header">
     <div class="menu__header-inner boxmenu__header-inner">
 
+      {{#if _boxmenu._graphic}}
+      <div class="menu__image-container boxmenu__image-container">
+        <img class="menu__image boxmenu__image" src="{{_boxmenu._graphic._src}}"{{#if _boxmenu._graphic.alt}} alt="{{_boxmenu._graphic.alt}}"{{/if}}{{#unless _boxmenu._graphic.alt}} aria-hidden="true"{{/unless}}>
+      </div>
+      {{/if}}
+
       {{#if displayTitle}}
       <div class="menu__title boxmenu__title">
         <div class="menu__title-inner boxmenu__title-inner js-heading"></div>

--- a/templates/boxMenu.hbs
+++ b/templates/boxMenu.hbs
@@ -6,9 +6,9 @@
   <div class="menu__header boxmenu__header">
     <div class="menu__header-inner boxmenu__header-inner">
 
-      {{#if _boxmenu._graphic}}
+      {{#if _boxMenu._graphic}}
       <div class="menu__image-container boxmenu__image-container">
-        <img class="menu__image boxmenu__image" src="{{_boxmenu._graphic._src}}"{{#if _boxmenu._graphic.alt}} alt="{{_boxmenu._graphic.alt}}"{{/if}}{{#unless _boxmenu._graphic.alt}} aria-hidden="true"{{/unless}}>
+        <img class="menu__image boxmenu__image" src="{{_boxMenu._graphic._src}}"{{#if _boxMenu._graphic.alt}} alt="{{_boxMenu._graphic.alt}}"{{/if}}{{#unless _boxMenu._graphic.alt}} aria-hidden="true"{{/unless}}>
       </div>
       {{/if}}
 


### PR DESCRIPTION
Fixes #133 

### New
* Add a new `_graphic` object that can be used to add an image (ex. a logo) above the menu title.

### Testing
1. In `course.json`, add the following:

```
  "_boxmenu": {
    "_graphic": {
      "alt": "Logo",
      "_src": "course/en/images/logo.png"
    }
  },
``` 
2. Ensure that the image appears above the menu title.
3. Ensure that either the alt text or aria-hidden="true" is included on the image.