### PR TITLE
Fix: Check for _graphic._src before displaying menu image (fixes #142)

### DIFF
--- a/templates/boxMenu.hbs
+++ b/templates/boxMenu.hbs
@@ -6,7 +6,7 @@
   <div class="menu__header boxmenu__header">
     <div class="menu__header-inner boxmenu__header-inner">
 
-      {{#if _boxMenu._graphic}}
+      {{#if _boxMenu._graphic._src }}
       <div class="menu__image-container boxmenu__image-container">
         <img class="menu__image boxmenu__image" src="{{_boxMenu._graphic._src}}"{{#if _boxMenu._graphic.alt}} alt="{{_boxMenu._graphic.alt}}"{{/if}}{{#unless _boxMenu._graphic.alt}} aria-hidden="true"{{/unless}}>
       </div>


### PR DESCRIPTION
Fixes #142 

### Fix
* In the template, check for `_boxMenu._graphic._src` instead of just `_boxMenu._graphic` before displaying the image
