### PR TITLE
Fix: Button aria contains text not accessible for translations (fixes #151)

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -4,6 +4,15 @@
   "id": "http://jsonschema.net",
   "$ref": "http://localhost/plugins/content/contentobject/model.schema",
   "globals": {
+    "itemCount": {
+      "type": "string",
+      "required": true,
+      "title": "Item count label",
+      "default": "Item {{itemNumber}} of {{totalItems}}",
+      "inputType": "Text",
+      "validators": [],
+      "translatable": true
+    },
     "durationLabel": {
       "type": "string",
       "required": true,

--- a/properties.schema
+++ b/properties.schema
@@ -8,7 +8,7 @@
       "type": "string",
       "required": true,
       "title": "Item count label",
-      "default": "Item {{itemNumber}} of {{totalItems}}",
+      "default": "Item {{_nthChild}} of {{_totalChild}}",
       "inputType": "Text",
       "validators": [],
       "translatable": true

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -24,7 +24,7 @@
                     "itemCount": {
                       "type": "string",
                       "title": "Item count label",
-                      "default": "Item {{itemNumber}} of {{totalItems}}",
+                      "default": "Item {{_nthChild}} of {{_totalChild}}",
                       "_adapt": {
                         "translatable": true
                       }

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -21,6 +21,14 @@
                   "title": "Box Menu",
                   "default": {},
                   "properties": {
+                    "itemCount": {
+                      "type": "string",
+                      "title": "Item count label",
+                      "default": "Item {{itemNumber}} of {{totalItems}}",
+                      "_adapt": {
+                        "translatable": true
+                      }
+                    },
                     "durationLabel": {
                       "type": "string",
                       "title": "Duration label",

--- a/templates/boxMenuItem.hbs
+++ b/templates/boxMenuItem.hbs
@@ -40,7 +40,7 @@
       </div>
 
       <div class="menu-item__button-container boxmenu-item__button-container">
-        <button class="btn-text menu-item__button boxmenu-item__button js-btn-click{{#if _isVisited}} is-visited{{/if}}{{#if _isLocked}} is-locked{{/if}}" aria-label="{{#if _isComplete}} {{_globals._accessibility._ariaLabels.complete}}.{{else _isVisited}} {{_globals._accessibility._ariaLabels.visited}}.{{/if}} {{linkText}} {{title}}. Item {{_nthChild}} of {{_totalChild}}.{{#if _isOptional}} {{_globals._accessibility._ariaLabels.optional}}{{/if}}"{{#if _isLocked}} aria-disabled="true"{{/if}}>
+        <button class="btn-text menu-item__button boxmenu-item__button js-btn-click{{#if _isVisited}} is-visited{{/if}}{{#if _isLocked}} is-locked{{/if}}" aria-label="{{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}. {{else _isVisited}}{{_globals._accessibility._ariaLabels.visited}}. {{/if}}{{linkText}} {{title}}. {{{compile _globals._menu._boxMenu.itemCount}}}.{{#if _isOptional}} {{_globals._accessibility._ariaLabels.optional}}{{/if}}"{{#if _isLocked}} aria-disabled="true"{{/if}}>
           {{{linkText}}}
         </button>
 


### PR DESCRIPTION
Fixes #151 

### Fix
* Adds new property `itemCount` with a default value of `Item {{_nthChild}} of {{_totalChild}}`
* Adjustments to space characters in button aria-label so that it doesn't start with a space.
