### PR TITLE
Fix: Update item count ARIA for grouped items (fixes #160)

### DIFF
--- a/js/BoxMenuGroupView.js
+++ b/js/BoxMenuGroupView.js
@@ -11,6 +11,19 @@ class BoxMenuGroupView extends MenuItemView {
     _.defer(this.addChildren.bind(this));
     this.$el.imageready(this.setReadyStatus.bind(this));
     this.$el.parents('.boxmenu__item-container').addClass('has-groups');
+    this.updateItemCount();
+  }
+
+  updateItemCount() {
+    let nthChild = 0;
+    const models = this.model.getChildren().models;
+    models.forEach(model => {
+      nthChild++;
+      model.set({
+        _nthChild: nthChild,
+        _totalChild: models.length
+      });
+    });
   }
 }
 

--- a/js/BoxMenuGroupView.js
+++ b/js/BoxMenuGroupView.js
@@ -15,12 +15,9 @@ class BoxMenuGroupView extends MenuItemView {
   }
 
   updateItemCount() {
-    let nthChild = 0;
     const models = this.model.getChildren().models;
     models.forEach(model => {
-      nthChild++;
       model.set({
-        _nthChild: nthChild,
         _totalChild: models.length
       });
     });

--- a/js/BoxMenuGroupView.js
+++ b/js/BoxMenuGroupView.js
@@ -16,9 +16,10 @@ class BoxMenuGroupView extends MenuItemView {
 
   updateItemCount() {
     const models = this.model.getChildren().models;
+    const totalChildren = models.length;
     models.forEach(model => {
       model.set({
-        _totalChild: models.length
+        _totalChild: totalChildren
       });
     });
   }

--- a/js/BoxMenuGroupView.js
+++ b/js/BoxMenuGroupView.js
@@ -17,11 +17,7 @@ class BoxMenuGroupView extends MenuItemView {
   updateItemCount() {
     const models = this.model.getChildren().models;
     const totalChildren = models.length;
-    models.forEach(model => {
-      model.set({
-        _totalChild: totalChildren
-      });
-    });
+    models.forEach(model => model.set('_totalChild', totalChildren));
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-boxMenu/issues/160

Item count is relevant to it's parent container (all items within Boxmenu as default, or items contained within a parent group).

**Test PR**
Configure your course to use the  Boxmenu grouping (see [example](https://github.com/adaptlearning/adapt-contrib-boxMenu/blob/1139ecbaf778365ef467f93117d93879bdba6884/example.json#L59) for ref).

Inspect 'View' Button `aria-label` and item count should be relevant to the Boxmenu group set up. 
e.g.  item index in group +  total items in group