### PR TITLE
Update: prepend locked ARIA to item button (fixes #182)

### DIFF
--- a/templates/boxMenuItem.hbs
+++ b/templates/boxMenuItem.hbs
@@ -40,7 +40,7 @@
       </div>
 
       <div class="menu-item__button-container boxmenu-item__button-container">
-        <button class="btn-text menu-item__button boxmenu-item__button js-btn-click{{#if _isVisited}} is-visited{{/if}}{{#if _isLocked}} is-locked{{/if}}" aria-label="{{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}. {{else _isVisited}}{{_globals._accessibility._ariaLabels.visited}}. {{/if}}{{linkText}} {{title}}. {{{compile _globals._menu._boxMenu.itemCount}}}.{{#if _isOptional}} {{_globals._accessibility._ariaLabels.optional}}{{/if}}"{{#if _isLocked}} aria-disabled="true"{{/if}} role="link">
+        <button class="btn-text menu-item__button boxmenu-item__button js-btn-click{{#if _isVisited}} is-visited{{/if}}{{#if _isLocked}} is-locked{{/if}}" aria-label="{{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}. {{else _isVisited}}{{_globals._accessibility._ariaLabels.visited}}. {{/if}}{{#if _isLocked}}{{_globals._accessibility._ariaLabels.locked}}. {{else}}{{linkText}} {{/if}}{{title}}. {{{compile _globals._menu._boxMenu.itemCount}}}.{{#if _isOptional}} {{_globals._accessibility._ariaLabels.optional}}{{/if}}"{{#if _isLocked}} aria-disabled="true"{{/if}} role="link">
           {{{linkText}}}
         </button>
 


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-boxMenu/issues/182

### Update
As per [Vanilla issue #446](https://github.com/adaptlearning/adapt-contrib-vanilla/issues/446), disabled locked buttons should have [_globals._accessibility._ariaLabels.locked](https://github.com/adaptlearning/adapt_framework/blob/c85bb887354dc07a44fb6e61779be584d81ede4a/src/course/en/course.json#L64) prepended to the button ARIA.

### Testing
Set `_lockType` in _course.json_, for example `"_lockType": "lockLast"`.

Locked menu items should have 'Locked' prepended to the button `aria-label` in place of the `linkText` 'View' text.
e.g. Locked. Adapt Assessment. Item 3 of 3.

When unlocked, button `aria-label` resumes `linkText`.
e.g. View Adapt Assessment. Item 3 of 3.


