### PR TITLE
New: Add option to make entire menu items clickable (fixes #157)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The first value is the horizontal position and the second value is the vertical.
 
 >>>**\_small** (number): The minimum height should only be used in instances where the menu header height needs to be greater than the content e.g. to prevent a background image being cropped.
 
->>>**__areEntireItemsClickable** (boolean): Indicates if the entire menu item can be clicked to go to the target page. If `true`, the View button will be hidden.
+>>>**\_areEntireItemsClickable** (boolean): Indicates if the entire menu item can be clicked to go to the target page. If `true`, the View button will be hidden.
 
 **\_globals** (object): The Globals object that contains value for **\_menu**.
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ The first value is the horizontal position and the second value is the vertical.
 
 >>>**\_small** (number): The minimum height should only be used in instances where the menu header height needs to be greater than the content e.g. to prevent a background image being cropped.
 
+>>>**__areEntireItemsClickable** (boolean): Indicates if the entire menu item can be clicked to go to the target page. If `true`, the View button will be hidden.
+
 **\_globals** (object): The Globals object that contains value for **\_menu**.
 
 >**\_menu** (object): The menu object that contains value for **\_boxMenu**.

--- a/example.json
+++ b/example.json
@@ -1,5 +1,6 @@
     // course.json
     "_boxMenu": {
+        "_areEntireItemsClickable": false,
         "_graphic": {
             "alt": "",
             "_src": "course/en/images/logo-graphic.jpg"
@@ -35,8 +36,7 @@
                 "_medium": 400,
                 "_small": 200
             }
-        },
-        "_areEntireItemsClickable": true,
+        }
     }
 
     // contentObjects.json

--- a/example.json
+++ b/example.json
@@ -35,7 +35,8 @@
                 "_medium": 400,
                 "_small": 200
             }
-        }
+        },
+        "_areEntireItemsClickable": true,
     }
 
     // contentObjects.json

--- a/js/BoxMenuItemView.js
+++ b/js/BoxMenuItemView.js
@@ -5,11 +5,11 @@ import router from 'core/js/router';
 class BoxMenuItemView extends MenuItemView {
 
   className() {
-    let classes = `${super.className()} boxmenu-item`;
-    if (this.areEntireItemsClickable()) {
-      classes += ' is-entire-item-clickable';
-    }
-    return classes;
+    return [
+      super.className(),
+      'boxmenu-item',
+      this.areEntireItemsClickable() && 'is-entire-item-clickable'
+    ].filter(Boolean).join(' ');
   }
 
   events() {
@@ -60,6 +60,7 @@ class BoxMenuItemView extends MenuItemView {
   }
 
   areEntireItemsClickable() {
+    console.log(this.model);
     return Adapt.course.get('_boxMenu')?._areEntireItemsClickable;
   }
 }

--- a/js/BoxMenuItemView.js
+++ b/js/BoxMenuItemView.js
@@ -8,7 +8,7 @@ class BoxMenuItemView extends MenuItemView {
     return [
       super.className(),
       'boxmenu-item',
-      this.areEntireItemsClickable() && 'is-entire-item-clickable'
+      this.areEntireItemsClickable && 'is-entire-item-clickable'
     ].filter(Boolean).join(' ');
   }
 
@@ -51,7 +51,7 @@ class BoxMenuItemView extends MenuItemView {
     router.navigateToElement(this.model.get('_id'));
   }
 
-  areEntireItemsClickable() {
+  get areEntireItemsClickable() {
     return Adapt.course.get('_boxMenu')?._areEntireItemsClickable;
   }
 }

--- a/js/BoxMenuItemView.js
+++ b/js/BoxMenuItemView.js
@@ -20,8 +20,8 @@ class BoxMenuItemView extends MenuItemView {
   }
 
   onClickMenuItemButton(event) {
-    if (event && event.preventDefault) event.preventDefault();
-    if (event.code && (event.code !== 'Space' && event.code !== 'Enter')) return;
+    if (event.code && !['Space', 'Enter'].includes(event.code)) return;
+    if (event?.preventDefault) event.preventDefault();
     if (this.model.get('_isLocked')) return;
     router.navigateToElement(this.model.get('_id'));
   }

--- a/js/BoxMenuItemView.js
+++ b/js/BoxMenuItemView.js
@@ -20,28 +20,19 @@ class BoxMenuItemView extends MenuItemView {
 
   attributes() {
     const globals = Adapt.course.get('_globals');
-    const ariaLabel = [];
-
-    if (this.model.get('_isComplete')) {
-      ariaLabel.push(globals._accessibility._ariaLabels.complete);
-    }
-
-    if (this.model.get('_isVisited')) {
-      ariaLabel.push(globals._accessibility._ariaLabels.visited);
-    }
-
-    if (this.model.get('_isOptional')) {
-      ariaLabel.push(globals._accessibility._ariaLabels.optional);
-    }
-
+    const ariaLabels = globals._accessibility._ariaLabels;
     const data = this.model.toJSON();
-    const itemCount = Handlebars.compile(globals._menu._boxMenu.itemCount)(data);
-    ariaLabel.push(itemCount);
+    const ariaLabel = [
+      this.model.get('_isComplete') && ariaLabels.complete,
+      this.model.get('_isVisited') && ariaLabels.visited,
+      this.model.get('_isOptional') && ariaLabels.optional,
+      Handlebars.compile(globals._menu._boxMenu.itemCount)(data)
+    ].filter(Boolean).join(' ');
 
     return {
       ...super.attributes(),
       role: 'link',
-      'aria-label': ariaLabel.join(' ')
+      'aria-label': ariaLabel
     };
   }
 

--- a/js/BoxMenuItemView.js
+++ b/js/BoxMenuItemView.js
@@ -1,15 +1,52 @@
 import MenuItemView from 'core/js/views/menuItemView';
+import Adapt from 'core/js/adapt';
 import router from 'core/js/router';
 
 class BoxMenuItemView extends MenuItemView {
 
   className() {
-    return `${super.className()} boxmenu-item`;
+    const entireItemClickable = this.areEntireItemsClickable() ? 'is-entire-item-clickable' : '';
+    return `${super.className()} boxmenu-item ${entireItemClickable}`;
   }
 
   events() {
+    if (this.areEntireItemsClickable()) {
+      return {
+        click: 'onClickMenuItemButton'
+      };
+    } else {
+      return {
+        'click .js-btn-click': 'onClickMenuItemButton'
+      };
+    }
+  }
+
+  attributes() {
+    const globals = Adapt.course.get('_globals');
+    const ariaLabel = [];
+
+    if (this.model.get('_isComplete')) {
+      ariaLabel.push(globals._accessibility._ariaLabels.complete);
+    }
+
+    if (this.model.get('_isVisited')) {
+      ariaLabel.push(globals._accessibility._ariaLabels.visited);
+    }
+
+    if (this.model.get('_isOptional')) {
+      ariaLabel.push(globals._accessibility._ariaLabels.optional);
+    }
+
+    const data = this.model.toJSON();
+    const itemCount = Handlebars.compile(globals._menu._boxMenu.itemCount)(data);
+    ariaLabel.push(itemCount);
+
+    const parentAttributes = Object.getPrototypeOf(BoxMenuItemView.prototype).attributes.call(this);
+
     return {
-      'click .js-btn-click': 'onClickMenuItemButton'
+      ...parentAttributes,
+      role: 'link',
+      'aria-label': ariaLabel.join(' ')
     };
   }
 
@@ -17,6 +54,10 @@ class BoxMenuItemView extends MenuItemView {
     if (event && event.preventDefault) event.preventDefault();
     if (this.model.get('_isLocked')) return;
     router.navigateToElement(this.model.get('_id'));
+  }
+
+  areEntireItemsClickable() {
+    return Adapt.course.get('_boxMenu')?._areEntireItemsClickable;
   }
 }
 

--- a/js/BoxMenuItemView.js
+++ b/js/BoxMenuItemView.js
@@ -22,11 +22,12 @@ class BoxMenuItemView extends MenuItemView {
     const globals = Adapt.course.get('_globals');
     const ariaLabels = globals._accessibility._ariaLabels;
     const data = this.model.toJSON();
+    const itemCount = globals._menu._boxMenu.itemCount;
     const ariaLabel = [
       this.model.get('_isComplete') && ariaLabels.complete,
       this.model.get('_isVisited') && ariaLabels.visited,
       this.model.get('_isOptional') && ariaLabels.optional,
-      Handlebars.compile(globals._menu._boxMenu.itemCount)(data)
+      Handlebars.compile(itemCount)(data)
     ].filter(Boolean).join(' ');
 
     return {

--- a/js/BoxMenuItemView.js
+++ b/js/BoxMenuItemView.js
@@ -18,25 +18,6 @@ class BoxMenuItemView extends MenuItemView {
     };
   }
 
-  attributes() {
-    const globals = Adapt.course.get('_globals');
-    const ariaLabels = globals._accessibility._ariaLabels;
-    const data = this.model.toJSON();
-    const itemCount = globals._menu._boxMenu.itemCount;
-    const ariaLabel = [
-      this.model.get('_isComplete') && ariaLabels.complete,
-      this.model.get('_isVisited') && ariaLabels.visited,
-      this.model.get('_isOptional') && ariaLabels.optional,
-      Handlebars.compile(itemCount)(data)
-    ].filter(Boolean).join(' ');
-
-    return {
-      ...super.attributes(),
-      role: 'link',
-      'aria-label': ariaLabel
-    };
-  }
-
   onClickMenuItemButton(event) {
     if (event && event.preventDefault) event.preventDefault();
     if (this.model.get('_isLocked')) return;

--- a/js/BoxMenuItemView.js
+++ b/js/BoxMenuItemView.js
@@ -44,10 +44,8 @@ class BoxMenuItemView extends MenuItemView {
     const itemCount = Handlebars.compile(globals._menu._boxMenu.itemCount)(data);
     ariaLabel.push(itemCount);
 
-    const parentAttributes = Object.getPrototypeOf(BoxMenuItemView.prototype).attributes.call(this);
-
     return {
-      ...parentAttributes,
+      ...super.attributes(),
       role: 'link',
       'aria-label': ariaLabel.join(' ')
     };

--- a/js/BoxMenuItemView.js
+++ b/js/BoxMenuItemView.js
@@ -13,12 +13,6 @@ class BoxMenuItemView extends MenuItemView {
   }
 
   events() {
-    if (this.areEntireItemsClickable()) {
-      return {
-        click: 'onClickMenuItemButton'
-      };
-    }
-
     return {
       'click .js-btn-click': 'onClickMenuItemButton'
     };
@@ -58,7 +52,6 @@ class BoxMenuItemView extends MenuItemView {
   }
 
   areEntireItemsClickable() {
-    console.log(this.model);
     return Adapt.course.get('_boxMenu')?._areEntireItemsClickable;
   }
 }

--- a/js/BoxMenuItemView.js
+++ b/js/BoxMenuItemView.js
@@ -5,8 +5,11 @@ import router from 'core/js/router';
 class BoxMenuItemView extends MenuItemView {
 
   className() {
-    const entireItemClickable = this.areEntireItemsClickable() ? 'is-entire-item-clickable' : '';
-    return `${super.className()} boxmenu-item ${entireItemClickable}`;
+    let classes = `${super.className()} boxmenu-item`;
+    if (this.areEntireItemsClickable()) {
+      classes += ' is-entire-item-clickable';
+    }
+    return classes;
   }
 
   events() {
@@ -14,11 +17,11 @@ class BoxMenuItemView extends MenuItemView {
       return {
         click: 'onClickMenuItemButton'
       };
-    } else {
-      return {
-        'click .js-btn-click': 'onClickMenuItemButton'
-      };
     }
+
+    return {
+      'click .js-btn-click': 'onClickMenuItemButton'
+    };
   }
 
   attributes() {

--- a/js/BoxMenuItemView.js
+++ b/js/BoxMenuItemView.js
@@ -14,12 +14,14 @@ class BoxMenuItemView extends MenuItemView {
 
   events() {
     return {
-      'click .js-btn-click': 'onClickMenuItemButton'
+      'click .js-btn-click': 'onClickMenuItemButton',
+      'keydown .js-btn-click': 'onClickMenuItemButton'
     };
   }
 
   onClickMenuItemButton(event) {
     if (event && event.preventDefault) event.preventDefault();
+    if (event.code && (event.code !== 'Space' && event.code !== 'Enter')) return;
     if (this.model.get('_isLocked')) return;
     router.navigateToElement(this.model.get('_id'));
   }

--- a/less/boxMenuItem.less
+++ b/less/boxMenuItem.less
@@ -8,4 +8,8 @@
   @media (min-width: @device-width-medium) {
     width: 50%;
   }
+
+  &.is-entire-item-clickable:not(.is-locked) {
+    cursor: pointer;
+  }
 }

--- a/properties.schema
+++ b/properties.schema
@@ -37,6 +37,15 @@
               "type": "object",
               "required": false,
               "properties": {
+                "_areEntireItemsClickable": {
+                  "type": "boolean",
+                  "required": false,
+                  "default": false,
+                  "title": "Are entire menu items clickable?",
+                  "inputType": "Checkbox",
+                  "validators": [],
+                  "help": "Enable this option to make each menu item clickable. The menu item button will be hidden."
+                },
                 "_graphic": {
                   "type": "object",
                   "required": false,

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -48,6 +48,12 @@
           "title": "Box Menu",
           "default": {},
           "properties": {
+            "_areEntireItemsClickable": {
+              "type": "boolean",
+              "title": "Are entire menu items clickable?",
+              "description": "Enable this option to make each menu item clickable. The menu item button will be hidden.",
+              "default": false
+            },
             "_graphic": {
               "type": "object",
               "title": "Menu logo image",

--- a/templates/boxMenuItem.hbs
+++ b/templates/boxMenuItem.hbs
@@ -1,12 +1,12 @@
 {{import_globals}}
 {{import_adapt}}
 
-<div class="menu-item__inner boxmenu-item__inner{{#if Adapt.course._boxMenu._areEntireItemsClickable}} js-btn-click{{/if}}" {{#if Adapt.course._boxMenu._areEntireItemsClickable}}role="link"{{#if _isLocked}} aria-disabled="true"{{/if}}{{/if}}>
+<div class="menu-item__inner boxmenu-item__inner{{#if Adapt.course._boxMenu._areEntireItemsClickable}} js-btn-click{{/if}}"{{#if Adapt.course._boxMenu._areEntireItemsClickable}} role="link"{{#if _isLocked}} aria-disabled="true"{{/if}}>
   {{#if Adapt.course._boxMenu._areEntireItemsClickable}}
   <span class="aria-label">
     {{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}. {{else _isVisited}}{{_globals._accessibility._ariaLabels.visited}}. {{/if}}{{#if _isLocked}}{{_globals._accessibility._ariaLabels.locked}}. {{else}}{{linkText}} {{/if}}{{title}}. {{{compile _globals._menu._boxMenu.itemCount}}}.{{#if _isOptional}} {{_globals._accessibility._ariaLabels.optional}}{{/if}}
   </span>
-  {{/if}
+  {{/if}}
 
   {{#if _graphic.src}}
   <div class="menu-item__image-container boxmenu-item__image-container">

--- a/templates/boxMenuItem.hbs
+++ b/templates/boxMenuItem.hbs
@@ -1,4 +1,5 @@
 {{import_globals}}
+{{import_adapt}}
 
 <div class="menu-item__inner boxmenu-item__inner">
 
@@ -40,9 +41,11 @@
       </div>
 
       <div class="menu-item__button-container boxmenu-item__button-container">
+        {{#unless Adapt.course._boxMenu._areEntireItemsClickable}}
         <button class="btn-text menu-item__button boxmenu-item__button js-btn-click{{#if _isVisited}} is-visited{{/if}}{{#if _isLocked}} is-locked{{/if}}" aria-label="{{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}. {{else _isVisited}}{{_globals._accessibility._ariaLabels.visited}}. {{/if}}{{#if _isLocked}}{{_globals._accessibility._ariaLabels.locked}}. {{else}}{{linkText}} {{/if}}{{title}}. {{{compile _globals._menu._boxMenu.itemCount}}}.{{#if _isOptional}} {{_globals._accessibility._ariaLabels.optional}}{{/if}}"{{#if _isLocked}} aria-disabled="true"{{/if}} role="link">
           {{{linkText}}}
         </button>
+        {{/unless}}
 
         <span class='menu-item__status boxmenu-item__status'>
           <span class='icon' aria-hidden="true"></span>

--- a/templates/boxMenuItem.hbs
+++ b/templates/boxMenuItem.hbs
@@ -1,7 +1,7 @@
 {{import_globals}}
 {{import_adapt}}
 
-<div class="menu-item__inner boxmenu-item__inner{{#if Adapt.course._boxMenu._areEntireItemsClickable}} js-btn-click{{/if}}"{{#if Adapt.course._boxMenu._areEntireItemsClickable}} role="link"{{#if _isLocked}} aria-disabled="true"{{/if}}>
+<div class="menu-item__inner boxmenu-item__inner{{#if Adapt.course._boxMenu._areEntireItemsClickable}} js-btn-click{{/if}}"{{#if Adapt.course._boxMenu._areEntireItemsClickable}} role="link"{{/if}}{{#if _isLocked}} aria-disabled="true"{{/if}}>
   {{#if Adapt.course._boxMenu._areEntireItemsClickable}}
   <span class="aria-label">
     {{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}. {{else _isVisited}}{{_globals._accessibility._ariaLabels.visited}}. {{/if}}{{#if _isLocked}}{{_globals._accessibility._ariaLabels.locked}}. {{else}}{{linkText}} {{/if}}{{title}}. {{{compile _globals._menu._boxMenu.itemCount}}}.{{#if _isOptional}} {{_globals._accessibility._ariaLabels.optional}}{{/if}}

--- a/templates/boxMenuItem.hbs
+++ b/templates/boxMenuItem.hbs
@@ -1,7 +1,7 @@
 {{import_globals}}
 {{import_adapt}}
 
-<div class="menu-item__inner boxmenu-item__inner{{#if Adapt.course._boxMenu._areEntireItemsClickable}} js-btn-click{{/if}}"{{#if Adapt.course._boxMenu._areEntireItemsClickable}} role="link"{{/if}}{{#if _isLocked}} aria-disabled="true"{{/if}}>
+<div class="menu-item__inner boxmenu-item__inner{{#if Adapt.course._boxMenu._areEntireItemsClickable}} js-btn-click{{/if}}"{{#if Adapt.course._boxMenu._areEntireItemsClickable}} role="link" tabindex="0"{{/if}}{{#if _isLocked}} aria-disabled="true"{{/if}}>
   {{#if Adapt.course._boxMenu._areEntireItemsClickable}}
   <span class="aria-label">
     {{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}. {{else _isVisited}}{{_globals._accessibility._ariaLabels.visited}}. {{/if}}{{#if _isLocked}}{{_globals._accessibility._ariaLabels.locked}}. {{else}}{{linkText}} {{/if}}{{title}}. {{{compile _globals._menu._boxMenu.itemCount}}}.{{#if _isOptional}} {{_globals._accessibility._ariaLabels.optional}}{{/if}}

--- a/templates/boxMenuItem.hbs
+++ b/templates/boxMenuItem.hbs
@@ -1,7 +1,7 @@
 {{import_globals}}
 {{import_adapt}}
 
-<div class="menu-item__inner boxmenu-item__inner{{#if Adapt.course._boxMenu._areEntireItemsClickable}} js-btn-click{{/if}}">
+<div {{#if Adapt.course._boxMenu._areEntireItemsClickable}}role="link" aria-label="{{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}. {{else _isVisited}}{{_globals._accessibility._ariaLabels.visited}}. {{/if}}{{#if _isLocked}}{{_globals._accessibility._ariaLabels.locked}}. {{else}}{{linkText}} {{/if}}{{title}}. {{{compile _globals._menu._boxMenu.itemCount}}}.{{#if _isOptional}} {{_globals._accessibility._ariaLabels.optional}}{{/if}}"{{/if}} class="menu-item__inner boxmenu-item__inner{{#if Adapt.course._boxMenu._areEntireItemsClickable}} js-btn-click{{/if}}">
 
   {{#if _graphic.src}}
   <div class="menu-item__image-container boxmenu-item__image-container">

--- a/templates/boxMenuItem.hbs
+++ b/templates/boxMenuItem.hbs
@@ -1,7 +1,12 @@
 {{import_globals}}
 {{import_adapt}}
 
-<div {{#if Adapt.course._boxMenu._areEntireItemsClickable}}role="link" aria-label="{{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}. {{else _isVisited}}{{_globals._accessibility._ariaLabels.visited}}. {{/if}}{{#if _isLocked}}{{_globals._accessibility._ariaLabels.locked}}. {{else}}{{linkText}} {{/if}}{{title}}. {{{compile _globals._menu._boxMenu.itemCount}}}.{{#if _isOptional}} {{_globals._accessibility._ariaLabels.optional}}{{/if}}"{{/if}} class="menu-item__inner boxmenu-item__inner{{#if Adapt.course._boxMenu._areEntireItemsClickable}} js-btn-click{{/if}}">
+<div class="menu-item__inner boxmenu-item__inner{{#if Adapt.course._boxMenu._areEntireItemsClickable}} js-btn-click{{/if}}" {{#if Adapt.course._boxMenu._areEntireItemsClickable}}role="link"{{#if _isLocked}} aria-disabled="true"{{/if}}{{/if}}>
+  {{#if Adapt.course._boxMenu._areEntireItemsClickable}}
+  <span class="aria-label">
+    {{#if _isComplete}}{{_globals._accessibility._ariaLabels.complete}}. {{else _isVisited}}{{_globals._accessibility._ariaLabels.visited}}. {{/if}}{{#if _isLocked}}{{_globals._accessibility._ariaLabels.locked}}. {{else}}{{linkText}} {{/if}}{{title}}. {{{compile _globals._menu._boxMenu.itemCount}}}.{{#if _isOptional}} {{_globals._accessibility._ariaLabels.optional}}{{/if}}
+  </span>
+  {{/if}
 
   {{#if _graphic.src}}
   <div class="menu-item__image-container boxmenu-item__image-container">

--- a/templates/boxMenuItem.hbs
+++ b/templates/boxMenuItem.hbs
@@ -1,7 +1,7 @@
 {{import_globals}}
 {{import_adapt}}
 
-<div class="menu-item__inner boxmenu-item__inner">
+<div class="menu-item__inner boxmenu-item__inner{{#if Adapt.course._boxMenu._areEntireItemsClickable}} js-btn-click{{/if}}">
 
   {{#if _graphic.src}}
   <div class="menu-item__image-container boxmenu-item__image-container">


### PR DESCRIPTION
Fixes #157 

### New
* Adds the `_areEntireItemsClickable` option to make entire menu items clickable
  * The "View" button will be hidden when this is `true`
  * This is a course-level setting rather than content object level (although we could move it)
* Updated documentation and schemas

### Testing
1. Add the `_areEntireItemsClickable` option to the `_boxMenu` object in _course.json_.
2. Click anywhere on the menu item to go to the content object.

### Screenshots
<img src="https://github.com/adaptlearning/adapt-contrib-boxMenu/assets/898168/a5c2faf2-2fc5-4d96-8136-26ce1c01ee82" width="450">
