### PR TITLE
New: support for responsive menu item image sources (fixes #198)

### DIFF
--- a/templates/boxMenuItem.jsx
+++ b/templates/boxMenuItem.jsx
@@ -41,6 +41,7 @@ export default function BoxMenuItem (props) {
       <templates.image {..._graphic}
         classNamePrefixes={['menu-item', 'boxmenu-item']}
         alt={null}
+        attribution={null}
       />
 
       <div className="menu-item__details boxmenu-item__details">

--- a/templates/boxMenuItem.jsx
+++ b/templates/boxMenuItem.jsx
@@ -40,7 +40,6 @@ export default function BoxMenuItem (props) {
 
       <templates.image {..._graphic}
         classNamePrefixes={['menu-item', 'boxmenu-item']}
-        attributionClassNamePrefixes={['menu-item', 'boxmenu-item']}
         alt={null}
       />
 

--- a/templates/boxMenuItem.jsx
+++ b/templates/boxMenuItem.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Adapt from 'core/js/adapt';
-import { classes, compile } from 'core/js/reactHelpers';
+import { classes, compile, templates } from 'core/js/reactHelpers';
 
 export default function BoxMenuItem (props) {
 
@@ -38,15 +38,11 @@ export default function BoxMenuItem (props) {
   return (
     <div className="menu-item__inner boxmenu-item__inner">
 
-      {_graphic?.src &&
-      <div className="menu-item__image-container boxmenu-item__image-container">
-        <img
-          className="menu-item__image boxmenu-item__image"
-          src={_graphic.src}
-          aria-hidden="true"
-        />
-      </div>
-      }
+      <templates.image {..._graphic}
+        classNamePrefixes={['menu-item', 'boxmenu-item']}
+        attributionClassNamePrefixes={['menu-item', 'boxmenu-item']}
+        alt={null}
+      />
 
       <div className="menu-item__details boxmenu-item__details">
         <div className="menu-item__details-inner boxmenu-item__details-inner">


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-boxMenu/issues/198

### Update
* Use image template for consistency with other plugin images and multi device support.

### New
* Support for device breakpoint sizes: `small`, `medium`, `large` and `xlarge`.
* When **only** `small` and `large` images are defined, images switch from `small` to `large` at `medium` (for separate mobile and desktop images).
**Note, this development is only available to the Framework at present until a core _contentobject.model.schema_ file is updated to offer up the flexibility to the AAT. This is also the case for all other plugins that use the image template.**

### Testing
Please test the following use cases. All code snippets reference pre-bundled course images.
1. Default support for src
```
    "_graphic": {
      "src": "course/en/images/menu-item.png",
      "alt": ""
    }
```
2. Mobile and desktop images
```
    "_graphic": {
      "large": "course/en/images/menu-item.png",
      "small": "course/en/images/gmcq.png",
      "alt": ""
    }
```
3. All device sizes
```
    "_graphic": {
      "xlarge": "course/en/images/vanilla-swatch.jpg",
      "large": "course/en/images/menu-item.png",
      "medium": "course/en/images/vanilla-swatch.jpg",
      "small": "course/en/images/gmcq.png",
      "alt": ""
    },
```
### Dependencies
Now that `.boxmenu-item__image-container` is a `<span>` (not `<div>`), [Vanilla](https://github.com/adaptlearning/adapt-contrib-vanilla/blob/62e4b3ef3ee6e6a26c9022b01dc15bc23ec7f661/less/plugins/adapt-contrib-boxmenu/boxMenuItem.less#L15) `margin-bottom` is no longer supported (inline elements only support horizontal margins). Instead, I'd suggest applying the `margin` to `.boxmenu-item__details` as per below. See Vanilla issue https://github.com/adaptlearning/adapt-contrib-vanilla/issues/520
```
.boxmenu-item {
  &__image-container + &__details {
    margin-top: @menu-item-image-margin;
  }
}
```
