### PR TITLE
Fix: Make _renderAsGroup as typegroup=group (fixes #212)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-boxMenu",
   "version": "7.1.1",
-  "framework": ">=5.24.2",
+  "framework": ">=5.48.4",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-boxMenu",
   "bugs": "https://github.com/adaptlearning/adapt-contrib-boxMenu/issues",
   "menu": "boxMenu",

--- a/js/BoxMenuModel.js
+++ b/js/BoxMenuModel.js
@@ -1,7 +1,5 @@
 import MenuModel from 'core/js/models/menuModel';
 
-/** @typedef {import("core/js/models/adaptModel").default} AdaptModel */
-
 export default class BoxMenuModel extends MenuModel {
 
   getTypeGroup() {

--- a/js/BoxMenuModel.js
+++ b/js/BoxMenuModel.js
@@ -1,3 +1,12 @@
 import MenuModel from 'core/js/models/menuModel';
 
-export default class BoxMenuModel extends MenuModel {}
+/** @typedef {import("core/js/models/adaptModel").default} AdaptModel */
+
+export default class BoxMenuModel extends MenuModel {
+
+  getTypeGroup() {
+    if (!this.get('_boxMenu')?._renderAsGroup) return;
+    return 'group';
+  }
+
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-boxMenu",
   "version": "7.1.1",
-  "framework": ">=5.24.2",
+  "framework": ">=5.48.4",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-boxMenu",
   "bugs": "https://github.com/adaptlearning/adapt-contrib-boxMenu/issues",
   "menu": "boxMenu",


### PR DESCRIPTION
fixes #212 

requires https://github.com/adaptlearning/adapt-contrib-core/pull/645

### Fix
* Allow core router to treat a group as a sub-part of the parent contentobject rather than as a main contentobject

