### PR TITLE
Update: provide alternative title text override for menu button ARIA label (fixes #214)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The following attributes, set within *contentObjects.json*, configure the defaul
 
 **displayTitle** (string):  This text is displayed on the menu item.
 
->**altTitle** (string): This will be read out by screen readers instead of **title** for the menu button text. Use if **title** contains punctuation or html syntax that shouldn't be read.
+>**titleAriaLabel** (string): This will be read out by screen readers instead of **title** for the menu button text. Use if **title** contains punctuation or html syntax that shouldn't be read.
 
 **body** (string):  Optional text that appears on the menu item. Often used to inform the learner about the menu choice. If no **pageBody** is supplied, this text will also appear as the body text of the page header.
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ The following attributes, set within *contentObjects.json*, configure the defaul
 
 **displayTitle** (string):  This text is displayed on the menu item.
 
+>**altTitle** (string): This will be read out by screen readers instead of **title** for the menu button text. Use if **title** contains punctuation or html syntax that shouldn't be read.
+
 **body** (string):  Optional text that appears on the menu item. Often used to inform the learner about the menu choice. If no **pageBody** is supplied, this text will also appear as the body text of the page header.
 
 **pageBody** (string): Optional text that appears as the body text of the page header. If this text is not provided, the **body** text will be used (if it is supplied). Reference [*adapt-contrib-vanilla/templates/page.hbs*](https://github.com/adaptlearning/adapt-contrib-vanilla/blob/master/templates/page.hbs).

--- a/example.json
+++ b/example.json
@@ -50,6 +50,7 @@
         "_isHidden": false,
         "title": "Welcome to Adapt Learning",
         "displayTitle": "Welcome to Adapt Learning",
+        "altTitle": "",
         "body": "This page contains a working Adapt page with all core bundled components and plugins working.",
         "_graphic": {
             "alt": "",

--- a/example.json
+++ b/example.json
@@ -50,7 +50,7 @@
         "_isHidden": false,
         "title": "Welcome to Adapt Learning",
         "displayTitle": "Welcome to Adapt Learning",
-        "altTitle": "",
+        "titleAriaLabel": "",
         "body": "This page contains a working Adapt page with all core bundled components and plugins working.",
         "_graphic": {
             "alt": "",

--- a/properties.schema
+++ b/properties.schema
@@ -289,6 +289,15 @@
               "type": "object",
               "required": false,
               "properties": {
+                "altTitle": {
+                  "type": "string",
+                  "inputType": "Text",
+                  "validators": [],
+                  "title": "Alternative Title",
+                  "help": "Alternative text read out by screen readers for the menu button text"
+                  "required": false,
+                  "translatable": true
+                },
                 "_renderAsGroup": {
                   "type": "boolean",
                   "required": false,

--- a/properties.schema
+++ b/properties.schema
@@ -289,12 +289,12 @@
               "type": "object",
               "required": false,
               "properties": {
-                "altTitle": {
+                "titleAriaLabel": {
                   "type": "string",
                   "inputType": "Text",
                   "validators": [],
-                  "title": "Alternative Title",
-                  "help": "Alternative text read out by screen readers for the menu button text"
+                  "title": "Title ARIA label",
+                  "help": "Alternative title text read out by screen readers for the menu button text"
                   "required": false,
                   "translatable": true
                 },

--- a/schema/contentobject.schema.json
+++ b/schema/contentobject.schema.json
@@ -13,6 +13,15 @@
           "title": "Box Menu",
           "default": {},
           "properties": {
+            "altTitle": {
+              "type": "string",
+              "title": "Alternative Title",
+              "description": "Alternative text read out by screen readers for the menu button text",
+              "default": "",
+              "_adapt": {
+                "translatable": true
+              }
+            },
             "_renderAsGroup": {
               "type": "boolean",
               "title": "Make this a parent group of menu items",

--- a/schema/contentobject.schema.json
+++ b/schema/contentobject.schema.json
@@ -13,10 +13,10 @@
           "title": "Box Menu",
           "default": {},
           "properties": {
-            "altTitle": {
+            "titleAriaLabel": {
               "type": "string",
-              "title": "Alternative Title",
-              "description": "Alternative text read out by screen readers for the menu button text",
+              "title": "Title ARIA label",
+              "description": "Alternative title text read out by screen readers for the menu button text",
               "default": "",
               "_adapt": {
                 "translatable": true

--- a/templates/boxMenuItem.jsx
+++ b/templates/boxMenuItem.jsx
@@ -14,6 +14,7 @@ export default function BoxMenuItem (props) {
     _isLocked,
     _isComplete,
     title,
+    altTitle,
     _isOptional,
     _nthChild,
     _totalChild
@@ -31,8 +32,9 @@ export default function BoxMenuItem (props) {
   const locked = _isLocked ? _globals?._accessibility?._ariaLabels?.locked : linkText;
   const optional = _isOptional ? _globals?._accessibility?._ariaLabels?.optional : '';
   const itemCount = compile(_globals?._menu?._boxMenu?.itemCount || '', { _nthChild, _totalChild });
+  const itemTitle = altTitle || title;
   const ariaLabel = [
-    completion, locked, `${title}.`, `${itemCount}.`, `${optional}`
+    completion, locked, `${itemTitle}.`, `${itemCount}.`, `${optional}`
   ].filter(Boolean).join(' ');
 
   return (

--- a/templates/boxMenuItem.jsx
+++ b/templates/boxMenuItem.jsx
@@ -14,7 +14,7 @@ export default function BoxMenuItem (props) {
     _isLocked,
     _isComplete,
     title,
-    altTitle,
+    titleAriaLabel,
     _isOptional,
     _nthChild,
     _totalChild
@@ -32,7 +32,7 @@ export default function BoxMenuItem (props) {
   const locked = _isLocked ? _globals?._accessibility?._ariaLabels?.locked : linkText;
   const optional = _isOptional ? _globals?._accessibility?._ariaLabels?.optional : '';
   const itemCount = compile(_globals?._menu?._boxMenu?.itemCount || '', { _nthChild, _totalChild });
-  const itemTitle = altTitle || title;
+  const itemTitle = titleAriaLabel || title;
   const ariaLabel = [
     completion, locked, `${itemTitle}.`, `${itemCount}.`, `${optional}`
   ].filter(Boolean).join(' ');


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt-contrib-boxMenu/issues/214

### Update
* Optional `titleAriaLabel` override provided to be read out by screen readers, instead of `title` for the menu item button ARIA label. To be used when `title` contains punctuation or html syntax that shouldn't be read. If `titleAriaLabel` isn't set, then `title` is used to label the menu item button as default.

Note, as per the issue comment, I'd initially suggested naming the override property `altTitle` for consistency with the alternative title created for [question feedback](https://github.com/adaptlearning/adapt-contrib-core/blob/75e0ab976e4d35eef44ab6a003167cc107eba305/js/models/questionModel.js#L295). However contentObject `altTitle` is already supported to provide an on screen alternative title for [PLP](https://github.com/adaptlearning/adapt-contrib-pageLevelProgress/pull/208). As the two use cases would require separate titles, I decided to create an separate property for `aria-label` only.

### Example use case
 
`title`: Being ‘on-spec’ (on screen text)
`titleAriaLabel`: Being on spec (`aria-label` text with no punctuation, spelt as should be read)