### PR TITLE
New: Add span wrapper around view button text (fixes #211)

### DIFF
--- a/templates/boxMenuItem.jsx
+++ b/templates/boxMenuItem.jsx
@@ -106,8 +106,12 @@ export default function BoxMenuItem (props) {
               aria-label={ariaLabel}
               aria-disabled={_isLocked ? true : null}
               role="link"
-              dangerouslySetInnerHTML={{ __html: compile(linkText) }}
-            />
+            >
+              <span
+                className="menu-item__button-text boxmenu-item__button-text"
+                dangerouslySetInnerHTML={{ __html: compile(linkText) }}
+              />
+            </button>
 
             <span className='menu-item__status boxmenu-item__status'>
               <span className='icon' aria-hidden="true" />


### PR DESCRIPTION
Fix #211 

### New
* Add a `span` wrapper around the view button text. This will make it easier to hide the text if we want an icon-only button.

### Notes
In a separate PR, I would like to introduce the option to add an icon to the button via config.
