### PR TITLE
Fix: updated `updateItemCount` to only count available children (fixes #218)

### DIFF
--- a/js/BoxMenuGroupView.js
+++ b/js/BoxMenuGroupView.js
@@ -16,7 +16,8 @@ class BoxMenuGroupView extends MenuItemView {
 
   updateItemCount() {
     const models = this.model.getChildren().where({
-      _isHidden: false
+      _isHidden: false,
+      _isAvailable: true
     });
     const totalChildren = models.length;
     models.forEach(model => model.set('_totalChild', totalChildren));


### PR DESCRIPTION
Fixes #218

### Fix
* Updated `updateItemCount` function to only count available children
