### PR TITLE
New: Add button icon option (fix #217)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,9 @@ The following attributes, set within *contentObjects.json*, configure the defaul
 
 **linkText** (string): This text is displayed on the menu item's link/button.
 
-**linkIconClass** (string): CSS class name to be applied to the `button` icon. The class must be predefined in one of the Less files with the corresponding icon included as part of a font. To have *no* icon, leave this field blank. See the list of all available [*vanilla* icons](https://github.com/adaptlearning/adapt-contrib-vanilla/wiki/Icons) to choose from.
+**_linkIconClass** (string): CSS class name to be applied to the `button` icon. The class must be predefined in one of the Less files with the corresponding icon included as part of a font. To have *no* icon, leave this field blank. See the list of all available [*vanilla* icons](https://github.com/adaptlearning/adapt-contrib-vanilla/wiki/Icons) to choose from.
 
-**linkIconPosition** (string): Determines how the icon is aligned to the text. Options include `left` and `right`. Defaults to `left` if left blank.
+**_linkIconPosition** (string): Determines how the icon is aligned to the text. Options include `left` and `right`. Defaults to `left` if left blank.
 
 **duration** (string): Optional text which follows **durationLabel** (e.g., `"2 mins"`).
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ The following attributes, set within *contentObjects.json*, configure the defaul
 
 **linkText** (string): This text is displayed on the menu item's link/button.
 
+**linkIconClass** (string): CSS class name to be applied to the `button` icon. The class must be predefined in one of the Less files with the corresponding icon included as part of a font. To have *no* icon, leave this field blank. See the list of all available [*vanilla* icons](https://github.com/adaptlearning/adapt-contrib-vanilla/wiki/Icons) to choose from.
+
+**linkIconPosition** (string): Determines how the icon is aligned to the text. Options include `left` and `right`. Defaults to `left` if left blank.
+
 **duration** (string): Optional text which follows **durationLabel** (e.g., `"2 mins"`).
 
 **\_boxMenu** (object): The boxMenu object that contains value for **\_renderAsGroup**.

--- a/example.json
+++ b/example.json
@@ -56,6 +56,8 @@
             "src": "course/en/images/origami-menu-one.jpg"
         },
         "linkText": "View",
+        "linkIconClass": "icon-controls-right",
+        "linkIconPosition": "left",
         "duration": "2 mins"
     }
 

--- a/example.json
+++ b/example.json
@@ -56,8 +56,8 @@
             "src": "course/en/images/origami-menu-one.jpg"
         },
         "linkText": "View",
-        "linkIconClass": "icon-controls-right",
-        "linkIconPosition": "left",
+        "_linkIconClass": "icon-controls-right",
+        "_linkIconPosition": "left",
         "duration": "2 mins"
     }
 

--- a/less/boxMenuItem.less
+++ b/less/boxMenuItem.less
@@ -12,4 +12,13 @@
   @media (min-width: @device-width-medium) {
     width: 50%;
   }
+
+  &__button {
+    display: flex;
+    column-gap: (@icon-padding / 4);
+
+    &.has-icon-right {
+      flex-direction: row-reverse;
+    }
+  }
 }

--- a/templates/boxMenuItem.jsx
+++ b/templates/boxMenuItem.jsx
@@ -102,7 +102,8 @@ export default function BoxMenuItem (props) {
                 'menu-item__button',
                 'boxmenu-item__button',
                 'js-btn-click',
-                _linkIconPosition && `has-icon-${_linkIconPosition}`,
+                _linkIconClass && 'has-icon',
+                (_linkIconClass && _linkIconPosition) && `has-icon-${_linkIconPosition}`,
                 _isVisited && 'is-visited',
                 _isLocked && 'is-locked'
               ])}

--- a/templates/boxMenuItem.jsx
+++ b/templates/boxMenuItem.jsx
@@ -10,8 +10,8 @@ export default function BoxMenuItem (props) {
     body,
     duration,
     linkText,
-    linkIconClass,
-    linkIconPosition,
+    _linkIconClass,
+    _linkIconPosition,
     _isVisited,
     _isLocked,
     _isComplete,
@@ -102,7 +102,7 @@ export default function BoxMenuItem (props) {
                 'menu-item__button',
                 'boxmenu-item__button',
                 'js-btn-click',
-                linkIconPosition && `has-icon-${linkIconPosition}`,
+                _linkIconPosition && `has-icon-${_linkIconPosition}`,
                 _isVisited && 'is-visited',
                 _isLocked && 'is-locked'
               ])}
@@ -110,11 +110,11 @@ export default function BoxMenuItem (props) {
               aria-disabled={_isLocked ? true : null}
               role="link"
             >
-              {linkIconClass &&
+              {_linkIconClass &&
                 <span className="menu-item__button-icon boxmenu-item__button-icon" aria-hidden="true">
                   <span className={classes([
                     'icon',
-                    linkIconClass
+                    _linkIconClass
                   ])} />
                 </span>
               }

--- a/templates/boxMenuItem.jsx
+++ b/templates/boxMenuItem.jsx
@@ -10,6 +10,8 @@ export default function BoxMenuItem (props) {
     body,
     duration,
     linkText,
+    linkIconClass,
+    linkIconPosition,
     _isVisited,
     _isLocked,
     _isComplete,
@@ -100,6 +102,7 @@ export default function BoxMenuItem (props) {
                 'menu-item__button',
                 'boxmenu-item__button',
                 'js-btn-click',
+                linkIconPosition && `has-icon-${linkIconPosition}`,
                 _isVisited && 'is-visited',
                 _isLocked && 'is-locked'
               ])}
@@ -107,6 +110,14 @@ export default function BoxMenuItem (props) {
               aria-disabled={_isLocked ? true : null}
               role="link"
             >
+              {linkIconClass &&
+                <span className="menu-item__button-icon boxmenu-item__button-icon" aria-hidden="true">
+                  <span className={classes([
+                    'icon',
+                    linkIconClass
+                  ])} />
+                </span>
+              }
               {linkText &&
               <span
                 className="menu-item__button-text boxmenu-item__button-text"


### PR DESCRIPTION
Fix #217 

### New
* Adds the option to have an icon on the link `<button>`
* New content object properties for `_linkIconClass` and `_linkIconPosition`

### Questions
* I did _not_ update any schemas. If we were to add this to schemas, should it go alongside `linkText` in the `adapt-contrib-core` content object schemas? Or should this be specific to Box Menu? If the latter, we would need to change the config to `_boxMenu._linkIconClass` and `_boxMenu._linkIconPosition`.

### Screenshots
<img src="https://github.com/user-attachments/assets/50bb4cad-f3ef-4ffe-9e92-fcbcc1ce826e" width="550">
