### PR TITLE
Fix: Prevent box menu from duplicating its items on repeat render (fixes #242)

### DIFF
--- a/js/BoxMenuView.js
+++ b/js/BoxMenuView.js
@@ -25,6 +25,10 @@ class BoxMenuView extends MenuView {
   }
 
   addChildren() {
+    // BoxMenu renders all children in a single pass. Ignore subsequent calls
+    // (e.g. triggered by trickle:kill) that would otherwise append a second
+    // full set of child views and duplicate the menu items.
+    if (this.getChildViews()) return;
     let nthChild = 0;
     const models = this.model.getChildren().models;
     const totalChild = this.model.getChildren().where({


### PR DESCRIPTION
Fixes #242

### Fix

`BoxMenuView.addChildren()` renders all children in a single pass and appends them to the container, but had no guard against being called again after the menu had already rendered. Anything that re-triggered child rendering (for example Trickle's `trickle:kill` event, which Dev Tools fires via its "Complete menu" button) caused a second full set of items to be appended, so every topic appeared twice.

Added an early return when child views already exist for the view instance. A freshly constructed view (e.g. when revisiting the menu) has no child views yet and still renders normally; only the redundant repeat call is skipped.

### Testing

1. Use a course with the box menu and Dev Tools enabled.
2. Open the menu, open Dev Tools, click "Complete menu".
3. The menu items should no longer be duplicated.

Or in the console:

```js
const Adapt = require('core/js/adapt').default;
Adapt.trigger('trickle:kill'); // item count should stay the same
```

Verified in Framework v5.56.2: with the fix, re-running `addChildren()` and firing `trickle:kill` both leave the item count unchanged (12 -> 12). Reverting the guard reproduces the doubling (12 -> 24).

Posted via collaboration with Claude Code